### PR TITLE
commented out <pathSeparator>:</pathSeparator> which doesn't work in …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
                         </goals>
                         <configuration>
                             <outputProperty>wildfly.module.classpath</outputProperty>
-                            <pathSeparator>:</pathSeparator>
+                            <!--pathSeparator>:</pathSeparator-->
                             <excludeGroupIds>javax</excludeGroupIds>
                             <excludeScope>test</excludeScope>
                             <includeScope>provided</includeScope>


### PR DESCRIPTION
…windows

<!--pathSeparator>:</pathSeparator-->

the default value of pathSeparator already assumes the correct system specific value:
: unix
; windows
