### PR TITLE
Need to exclude JBeret subsystem.

### DIFF
--- a/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -5,6 +5,11 @@
             <module name="org.wildfly.jberet"/>
             <module name="org.jberet.jberet-core"/>
         </exclusions>
+        <!-- With WildFly 10, Spring batch 3.0.7 I needed to explicitly exclude whole jberet subsystem,
+        otherwise two JSR 352 providers are loaded and they clash -->
+        <exclude-subsystems>
+            <subsystem name="batch-jberet"/>
+        </exclude-subsystems>
 
         <dependencies>
             <module name="org.springframework.batch" services="import" meta-inf="import"/>


### PR DESCRIPTION
With WildFly 10, Spring batch 3.0.7, I needed to explicitly exclude whole jberet subsystem, otherwise two JSR 352 providers are loaded and clash. I've got this hint /solution during a chat which some developers / users of Wildfly on WildFly's site, and I thought it would be nice to share it.
